### PR TITLE
Data mapping & Query bugfix

### DIFF
--- a/gits.go
+++ b/gits.go
@@ -1881,10 +1881,10 @@ func mapRecursive(entity transport.TransportEntity, relatedType int, relatedID i
 	if len(entity.ParentRelations) != 0 {
 		// there are children lets iteater over
 		// the map
-		for _, childRelation := range entity.ChildRelations {
+		for _, parentRelation := range entity.ParentRelations {
 			// pas the child entity and the parent coords to
 			// create the relation after inserting the entity
-			mapRecursive(childRelation.Target, TypeID, mapID, DIRECTION_PARENT)
+			mapRecursive(parentRelation.Target, TypeID, mapID, DIRECTION_PARENT)
 		}
 	}
 	// now lets check if ourparent Type and id

--- a/src/query/query.go
+++ b/src/query/query.go
@@ -425,7 +425,7 @@ func recursiveExecuteLinked(queries []Query, sourceAddress [2]int, addressPairLi
 					resultData[key].Target.ChildRelations = append(resultData[key].Target.ChildRelations, children...)
 				}
 				if 0 < len(parents) {
-					resultData[key].Target.ParentRelations = append(resultData[key].Target.ParentRelations, children...)
+					resultData[key].Target.ParentRelations = append(resultData[key].Target.ParentRelations, parents...)
 				}
 				if 0 < amount || !query.HasRequiredSubQueries() {
 					tmpRet = append(tmpRet, resultData[key])


### PR DESCRIPTION
> Bugfixing an issue that prevented from using gits.MapTransportData to map towards parents
> Bugfixing an issue that prevented from correctly getting the return data on subquerying towards parents