### PR TITLE
Enable delete cascade

### DIFF
--- a/DOCS/QUERY.md
+++ b/DOCS/QUERY.md
@@ -63,7 +63,12 @@ The GITS Query Language is a custom implementation optimized for the usage with 
 * **TraverseOut(depth int)**: Traverses relationships outward (children) from the current entity up to a specified depth.
 * **TraverseIn(depth int)**: Traverses relationships inward (parents) up to a specified depth.
 
-**7. Executing the Query**
+**7. Cascading Delete**
+* **CascadeOut(depth int)**: Cascades relationships outward (children) from the current entity up to a specified depth and delete's them. When provided depth 0 it will follow relations without depth limitation
+* **CascadeIn(depth int)**: Traverses relationships inward (parents) up to a specified depth and delete's them. When provided depth 0 it will follow relations without depth limitation
+
+
+**8. Executing the Query**
 * **gitsInstance.Query().Execute(query *Query)**: Executes the query and returns the results.
 
 In the next step, we will provide practical examples to illustrate how to use these methods to construct complex queries. The query return prints will be in json format for practical reasons.


### PR DESCRIPTION
- Adding CascadeIn(depth int) and CascadeOut(depth) mthods to Query struct, which can be used to have deletes cascade over multiple levels.
- Adding tests for CascadeIn and CascadeOut
- Adding base info for Cascade methods to docs